### PR TITLE
Redesign Date Difference display options & result

### DIFF
--- a/Localizable.xcstrings
+++ b/Localizable.xcstrings
@@ -1936,6 +1936,17 @@
         }
       }
     },
+    "Show" : {
+      "comment" : "Date difference",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Anzeigen"
+          }
+        }
+      }
+    },
     "Show Again" : {
       "localizations" : {
         "de" : {

--- a/Toolbox/Functions/DateDifference.swift
+++ b/Toolbox/Functions/DateDifference.swift
@@ -11,13 +11,10 @@ struct DateDifference: View{
     }
     func calcDiff(from start: Date, to end: Date) -> (years: Int, months: Int, days: Int) {
         let calendar = Calendar.current
-        
-        print("Start: \(start); End: \(end)")
+
         let startDate = removeTimeFromDate(min(start, end))
         let endDate = removeTimeFromDate(max(start, end))
-        print("Start: \(startDate); End: \(endDate)")
-        print("-------------------------------------------------------------")
-        
+
         var elements: Set<Calendar.Component> = []
         if(displayDays) {
             elements.insert(Calendar.Component.day)
@@ -28,19 +25,19 @@ struct DateDifference: View{
         if(displayMonths) {
             elements.insert(Calendar.Component.month)
         }
-        
+
         let components = calendar.dateComponents(elements, from: startDate, to: endDate)
-        
+
         return (years: components.year ?? 0, months: components.month ?? 0, days: components.day ?? 0)
     }
-        
+
     @State private var dateFrom = Date()
     @State private var dateTo = Date()
     @AppStorage("dateDiffYears") var displayYears = true
     @AppStorage("dateDiffMonths") var displayMonths = true
     @AppStorage("dateDiffDays") var displayDays = true
     @State var isPresentingToast: Bool = false
-    
+
     func presentToast() {
         withAnimation {
             isPresentingToast = true
@@ -51,65 +48,181 @@ struct DateDifference: View{
             }
         }
     }
-    
 
-    
-    
+    /// Flips one unit on/off, but never lets the user disable the last remaining unit.
+    /// The animation is declarative (`.animation(_:value:)` on the grid / chip) rather than
+    /// wrapped here — that is what actually plays now that the result lives in a `ScrollView`
+    /// instead of a `Form`, whose list cells suppress internal insert/remove transitions.
+    private func toggleUnit(_ binding: Binding<Bool>) {
+        let activeCount = [displayYears, displayMonths, displayDays].filter { $0 }.count
+        if binding.wrappedValue && activeCount <= 1 { return }
+        Haptic.impact(.light).generate()
+        binding.wrappedValue.toggle()
+    }
+
+    private func isOn(_ unit: DiffUnit) -> Bool {
+        switch unit {
+        case .years: return displayYears
+        case .months: return displayMonths
+        case .days: return displayDays
+        }
+    }
+
+    private func value(_ unit: DiffUnit, in diff: (years: Int, months: Int, days: Int)) -> Int {
+        switch unit {
+        case .years: return diff.years
+        case .months: return diff.months
+        case .days: return diff.days
+        }
+    }
+
+    /// Active units in reading order (largest first) for both the result grid and the copy string.
+    private var activeUnits: [DiffUnit] {
+        DiffUnit.allCases.filter { isOn($0) }
+    }
+
     var body: some View{
-        
-        Form{
-            DatePicker(
-                "Start Date",
-                selection: $dateFrom,
-                displayedComponents: [.date]
-            )
-            .datePickerStyle(.automatic)
-            
-            DatePicker(
-                "End Date",
-                selection: $dateTo,
-                displayedComponents: [.date]
-            )
-            .datePickerStyle(.automatic)
-            
-            Section {
-                DisclosureGroup("Display") {
-                    Toggle(isOn: $displayDays) {
-                        Text("Days")
-                    }
-                    .disabled(!displayYears && !displayMonths)
-                    
-                    Toggle(isOn: $displayMonths) {
-                        Text("Months")
-                    }
-                    .disabled(!displayDays && !displayYears)
 
-                    Toggle(isOn: $displayYears) {
-                        Text("Years")
+        let diff = calcDiff(from: dateFrom, to: dateTo)
+        let units = activeUnits
+
+        ScrollView {
+            VStack(spacing: 26) {
+
+                // Dates
+                card {
+                    VStack(spacing: 14) {
+                        DatePicker("Start Date", selection: $dateFrom, displayedComponents: [.date])
+                        Divider()
+                        DatePicker("End Date", selection: $dateTo, displayedComponents: [.date])
                     }
-                    .disabled(!displayDays && !displayMonths)
+                }
+
+                // Unit selection
+                section(NSLocalizedString("Show", comment: "Date difference")) {
+                    HStack(spacing: 8) {
+                        UnitChip(title: NSLocalizedString("Years", comment: "Date difference"),
+                                 isOn: displayYears) { toggleUnit($displayYears) }
+                        UnitChip(title: NSLocalizedString("Months", comment: "Date difference"),
+                                 isOn: displayMonths) { toggleUnit($displayMonths) }
+                        UnitChip(title: NSLocalizedString("Days", comment: "Date difference"),
+                                 isOn: displayDays) { toggleUnit($displayDays) }
+                    }
+                }
+
+                // Result
+                section(NSLocalizedString("Difference", comment: "Date difference")) {
+                    Button {
+                        let text = units.map { "\(value($0, in: diff)) \($0.label)" }.joined(separator: ", ")
+                        UIPasteboard.general.string = text
+                        Haptic.impact(.light).generate()
+                        presentToast()
+                    } label: {
+                        HStack(spacing: 0) {
+                            ForEach(units) { unit in
+                                HStack(spacing: 0) {
+                                    if unit != units.first {
+                                        Divider().frame(height: 36)
+                                    }
+                                    VStack(spacing: 4) {
+                                        Text("\(value(unit, in: diff))")
+                                            .font(.system(size: 34, weight: .semibold, design: .rounded))
+                                            .foregroundStyle(.primary)
+                                            .contentTransition(.numericText())
+                                            .monospacedDigit()
+                                        Text(unit.label.uppercased())
+                                            .font(.caption2.weight(.semibold))
+                                            .foregroundStyle(.secondary)
+                                    }
+                                    .frame(maxWidth: .infinity)
+                                }
+                                .transition(.scale(scale: 0.6).combined(with: .opacity))
+                            }
+                        }
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 4)
+                        .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                    .animation(.snappy, value: units)
                 }
             }
-
-            Section("Difference") {
-                
-                if displayDays {
-                    KeyValueProperty(content: String(calcDiff(from: dateFrom, to: dateTo).days), propertyName: NSLocalizedString("Days", comment: "Date difference"))
-                }
-                
-                if displayMonths {
-                    KeyValueProperty(content: String(calcDiff(from: dateFrom, to: dateTo).months), propertyName: NSLocalizedString("Months", comment: "Date difference"))
-                }
-                
-                if displayYears {
-                    KeyValueProperty(content: String(calcDiff(from: dateFrom, to: dateTo).years), propertyName: NSLocalizedString("Years", comment: "Date difference"))
-                }
-            }.transition(.slide)
-            
+            .padding(.horizontal, 16)
+            .padding(.vertical, 22)
         }
-        
+        .background(Color(.systemGroupedBackground))
         .toast(isPresenting: $isPresentingToast, message: NSLocalizedString("Copied", comment: "Copy toast"), icon: .custom(Image(systemName: "doc.on.clipboard")), autoDismiss: .none)
-        .navigationBarTitleDisplayMode(/*@START_MENU_TOKEN@*/.inline/*@END_MENU_TOKEN@*/)
+        .navigationBarTitleDisplayMode(.inline)
         .navigationTitle("Date Difference")
+    }
+
+    /// A white, rounded grouped card — mirrors the look of the app's `Form` rows so the
+    /// screen fits in, while living outside a `List` so animations aren't suppressed.
+    private func card<Content: View>(@ViewBuilder _ content: () -> Content) -> some View {
+        content()
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(16)
+            .background(Color(.secondarySystemGroupedBackground), in: RoundedRectangle(cornerRadius: 16))
+    }
+
+    /// A grouped card with a leading, uppercase section header above it — the `Form` look.
+    private func section<Content: View>(_ header: String, @ViewBuilder content: () -> Content) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(header)
+                .font(.footnote)
+                .textCase(.uppercase)
+                .foregroundStyle(.secondary)
+                .padding(.leading, 16)
+            card(content)
+        }
+    }
+}
+
+/// The three units the difference can be broken down into, in reading order (largest first).
+/// A stable, per-unit identity is what keeps the result grid animating cleanly as units are
+/// toggled — index-based identity makes SwiftUI treat a removal as an in-place content change.
+private enum DiffUnit: String, CaseIterable, Identifiable {
+    case years, months, days
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .years: return NSLocalizedString("Years", comment: "Date difference")
+        case .months: return NSLocalizedString("Months", comment: "Date difference")
+        case .days: return NSLocalizedString("Days", comment: "Date difference")
+        }
+    }
+}
+
+/// A tappable, capsule-shaped unit selector that fills with the accent colour when active.
+private struct UnitChip: View {
+    let title: String
+    let isOn: Bool
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Text(title)
+                .font(.subheadline.weight(.semibold))
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 10)
+                .background(
+                    Capsule()
+                        .fill(isOn ? Color.accentColor : Color(.tertiarySystemFill))
+                )
+                .foregroundStyle(isOn ? Color.white : Color.primary)
+                .animation(.snappy, value: isOn)
+        }
+        .buttonStyle(ChipButtonStyle())
+    }
+}
+
+/// Gives the chips a subtle, consistent press-down feedback instead of the default fade.
+private struct ChipButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .scaleEffect(configuration.isPressed ? 0.94 : 1)
+            .animation(.snappy(duration: 0.18), value: configuration.isPressed)
     }
 }


### PR DESCRIPTION
## What

Reworks the **Date Difference** tool's UI, focused on the display options the user found clunky.

**Display options ("Show")**
- Replaces the collapsed `DisclosureGroup("Display")` + three `Toggle`s (with awkward `disabled` logic) with a visible row of tappable capsule **chips**: Years / Months / Days.
- Active chips fill with the accent colour; the last active chip can't be turned off; light haptic + a subtle press-scale for feedback.

**Result ("Difference")**
- Replaces the plain `KeyValueProperty` rows with a rounded **numeric hero** (big rounded digits + unit labels, thin dividers), largest unit first.
- Tapping the card copies the full breakdown (e.g. `2 Years, 3 Months, 5 Days`) — the copy affordance is preserved, just cleaner.

## Why the screen moved from `Form` to `ScrollView`

The result grid **jumped** instead of animating when toggling a unit. Root cause: SwiftUI `List`/`Form` cells suppress insert/remove transitions of their inner content — no modifier (`withAnimation` or `.animation(value:)`) fixes that while the grid lives in a Form section. The screen now uses a `ScrollView` with small `card { }` / `section { }` helpers that reproduce the grouped look 1:1, so transitions play normally:
- `.animation(.snappy, value: units)` drives column add/remove (`.scale + .opacity`), each column keyed by a stable per-unit identity.
- `.animation(.snappy, value: isOn)` drives the chip fill.

## Other

- Difference is now computed **once per render** instead of up to 6×.
- Adds the `Show` string (+ German `Anzeigen`) to `Localizable.xcstrings`, matching Xcode's format so the catalog diff stays minimal.

## Reviewer notes

- Visual look is unchanged from the previous grouped/Form style (custom cards mirror `secondarySystemGroupedBackground` on `systemGroupedBackground`).
- Chip colour uses the app accent (red), consistent with other tools; confirmed with the author.
- Not touched: the WhatsNewKit collection — can be bumped separately when this ships as a user-visible release.

## Testing

- Builds clean for the iOS Simulator.
- Verified the redesigned layout renders correctly in the simulator. The toggle animation itself was reviewed in code (the automation panel couldn't reliably deliver taps to the chips) — worth a quick manual check that toggling a unit glides rather than jumps.